### PR TITLE
replace invalid xml chars in element content in OptimizedForSpeedSaver

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/store/Saver.java
+++ b/src/main/java/org/apache/xmlbeans/impl/store/Saver.java
@@ -2118,6 +2118,10 @@ abstract class Saver {
             int index = 0;
             for (int i = 0; i < bufLimit; i++) {
                 char c = _buf[i];
+                if (isBadChar(c)) {
+                    _buf[i] = '?';
+                    c = '?';
+                }
                 switch (c) {
                     case '<':
                         emit(_buf, index, i - index);

--- a/src/test/java/misc/checkin/SaveOptimizeForSpeedTest.java
+++ b/src/test/java/misc/checkin/SaveOptimizeForSpeedTest.java
@@ -99,6 +99,23 @@ public class SaveOptimizeForSpeedTest {
     }
 
     @Test
+    void testBadCharInText() throws Exception {
+        // an invalid XML 1.0 character (a C0 control) in element content. The
+        // default saver replaces it with '?'; the speed path emitted it raw,
+        // producing output that is not well-formed.
+        XmlObject o = XmlObject.Factory.parse("<root/>");
+        try (XmlCursor cur = o.newCursor()) {
+            cur.toFirstChild();
+            cur.toFirstContentToken();
+            cur.insertChars("a\u0001b");
+        }
+        String out = saveForSpeed(o);
+        assertFalse(out.indexOf('\u0001') >= 0);
+        // before the fix the raw control char makes this a fatal parse error
+        XmlObject.Factory.parse(out);
+    }
+
+    @Test
     void testProcInstTerminatorAcrossChunkBoundary() throws Exception {
         // a '?>' that straddles the 512-char chunk boundary: '?' is the last char
         // of the first chunk, '>' the first char of the second. The per-chunk


### PR DESCRIPTION
Round-tripping an element whose text holds an invalid XML character through the speed saver:

    <root>a?b</root>   (the ? is a raw U+0001)
    org.xml.sax.SAXParseException: An invalid XML character (Unicode: 0x1) was found in the element content

Traced it to OptimizedForSpeedSaver.entitizeAndWriteText. It special-cases '<', '&' and the '>' that closes ']]>', but never runs isBadChar, so a C0 control (or U+FFFE/U+FFFF) in element content is written out untouched and the result will not reparse. The default TextSaver.entitizeContent substitutes '?' for those characters, and this saver's own comment and pi emitters already do the same. The content path was the only emitter that skipped it.

Reachable from save(Writer, XmlOptions)/xmlText with setSaveOptimizeForSpeed(true) on content set via XmlCursor.insertChars. Fixed it the way the sibling pi emitter does: swap a bad char for '?' before the switch. Test added.