### PR TITLE
wrap getDate() IllegalStateException in rich parser date getters

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/richParser/XMLStreamReaderExtImpl.java
+++ b/src/main/java/org/apache/xmlbeans/impl/richParser/XMLStreamReaderExtImpl.java
@@ -205,7 +205,7 @@ public class XMLStreamReaderExtImpl
         _charSeq.reload(CharSeqTrimWS.XMLWHITESPACE_TRIM);
         try {
             return new GDateBuilder(_charSeq).getDate();
-        } catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException | IllegalStateException e) {
             throw new InvalidLexicalValueException(e, _charSeq.getLocation());
         }
     }
@@ -353,7 +353,7 @@ public class XMLStreamReaderExtImpl
         try {
             return new GDateBuilder(_charSeq.reloadAtt(index, CharSeqTrimWS.XMLWHITESPACE_TRIM))
                 .getDate();
-        } catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException | IllegalStateException e) {
             throw new InvalidLexicalValueException(e, _charSeq.getLocation());
         }
     }
@@ -507,7 +507,7 @@ public class XMLStreamReaderExtImpl
         try {
             CharSequence cs = _charSeq.reloadAtt(uri, local, CharSeqTrimWS.XMLWHITESPACE_TRIM);
             return new GDateBuilder(cs).getDate();
-        } catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException | IllegalStateException e) {
             throw new InvalidLexicalValueException(e, _charSeq.getLocation());
         }
     }

--- a/src/test/java/misc/checkin/RichParserTests.java
+++ b/src/test/java/misc/checkin/RichParserTests.java
@@ -107,6 +107,35 @@ public class RichParserTests {
         assertEquals(new QName("urn:x", "good"), good.getQNameValue());
     }
 
+    @Test
+    void testInvalidDateThrowsInvalidLexicalValue() throws Exception {
+        // getDateValue converts the parsed GDate to a java.util.Date via
+        // GDateBuilder.getDate(), which throws IllegalStateException - not
+        // IllegalArgumentException - when the value is not a complete date
+        // (a time/gYear/gYearMonth reaching a dateTime field) or its year is
+        // before the Julian epoch. The getter only caught IllegalArgumentException
+        // so the IllegalStateException escaped instead of the documented
+        // InvalidLexicalValueException the other getters surface.
+        XMLStreamReaderExt timeOnly = atFirstStartElement("<a>12:00:00</a>");
+        assertThrows(InvalidLexicalValueException.class, timeOnly::getDateValue);
+
+        XMLStreamReaderExt yearOnly = atFirstStartElement("<a>2001</a>");
+        assertThrows(InvalidLexicalValueException.class, yearOnly::getDateValue);
+
+        XMLStreamReaderExt ancient = atFirstStartElement("<a>-5000-01-01T00:00:00Z</a>");
+        assertThrows(InvalidLexicalValueException.class, ancient::getDateValue);
+
+        XMLStreamReaderExt attByIndex = atFirstStartElement("<a b='12:00:00'/>");
+        assertThrows(InvalidLexicalValueException.class, () -> attByIndex.getAttributeDateValue(0));
+
+        XMLStreamReaderExt attByName = atFirstStartElement("<a b='12:00:00'/>");
+        assertThrows(InvalidLexicalValueException.class, () -> attByName.getAttributeDateValue("", "b"));
+
+        // a well-formed dateTime still converts
+        XMLStreamReaderExt good = atFirstStartElement("<a>2001-11-26T21:32:52Z</a>");
+        assertEquals(new XmlCalendar("2001-11-26T21:32:52Z").getTime(), good.getDateValue());
+    }
+
     private static XMLStreamReaderExt atFirstStartElement(String xml) throws Exception {
         XMLStreamReader xsr = XmlObject.Factory.parse(xml).newXMLStreamReader();
         XMLStreamReaderExt ext = new XMLStreamReaderExtImpl(xsr);


### PR DESCRIPTION
Rich parser threw on an xsd:dateTime element instead of reporting a bad value:

    java.lang.IllegalStateException: cannot do date math without a complete date
        at org.apache.xmlbeans.GDateBuilder.julianDateForGDate(GDateBuilder.java:1079)
        at org.apache.xmlbeans.GDateBuilder.dateForGDate(GDateBuilder.java:1099)
        at org.apache.xmlbeans.GDateBuilder.getDate(GDateBuilder.java:1073)
        at org.apache.xmlbeans.impl.richParser.XMLStreamReaderExtImpl.getDateValue(XMLStreamReaderExtImpl.java:206)

getDateValue turns the parsed GDate into a java.util.Date via GDateBuilder.getDate(). getDate() throws IllegalStateException, not IllegalArgumentException, when the value is not a complete date (a time, gYear or gYearMonth reaching the field) or its year is before the Julian epoch. The getter caught only IllegalArgumentException, so the IllegalStateException escaped.

Traced the same shape through getAttributeDateValue by index and by name. getCalendarValue is unaffected since getCalendar() only sets calendar fields, and getGDateValue returns the GDate without the Date conversion.

The other getters and the JavaGDateHolderEx validate path already surface a bad value as InvalidLexicalValueException. Widened the catch on the three getDate() sites to match, and added a test driving the time, gYear and pre-epoch cases plus the attribute overloads.