### PR TITLE
escape comment trailing dash only on the final chunk in speed saver

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/store/Saver.java
+++ b/src/main/java/org/apache/xmlbeans/impl/store/Saver.java
@@ -2106,10 +2106,11 @@ abstract class Saver {
             int cch = c._cchSrc;
             int off = c._offSrc;
             int index = 0;
+            boolean lastWasDash = false;
             while (index < cch) {
                 int indexLimit = Math.min(index + 512, cch);
                 CharUtil.getChars(_buf, 0, src, off + index, indexLimit - index);
-                entitizeAndWriteCommentText(indexLimit - index);
+                lastWasDash = entitizeAndWriteCommentText(indexLimit - index, lastWasDash, indexLimit == cch);
                 index = indexLimit;
             }
         }
@@ -2156,9 +2157,7 @@ abstract class Saver {
             return trailingBrackets;
         }
 
-        private void entitizeAndWriteCommentText(int bufLimit) {
-            boolean lastWasDash = false;
-
+        private boolean entitizeAndWriteCommentText(int bufLimit, boolean lastWasDash, boolean lastChunk) {
             for (int i = 0; i < bufLimit; i++) {
                 char ch = _buf[i];
 
@@ -2181,11 +2180,15 @@ abstract class Saver {
                 }
             }
 
-            if (_buf[bufLimit - 1] == '-') {
+            // A trailing '-' would form "--->" with the closing delimiter, so it
+            // is escaped only at the real end of the comment, not on every chunk.
+            if (lastChunk && _buf[bufLimit - 1] == '-') {
                 _buf[bufLimit - 1] = ' ';
+                lastWasDash = false;
             }
 
             emit(_buf, 0, bufLimit);
+            return lastWasDash;
         }
 
         private boolean entitizeAndWritePIText(int bufLimit, boolean lastWasQuestion) {

--- a/src/test/java/misc/checkin/SaveOptimizeForSpeedTest.java
+++ b/src/test/java/misc/checkin/SaveOptimizeForSpeedTest.java
@@ -116,6 +116,19 @@ public class SaveOptimizeForSpeedTest {
     }
 
     @Test
+    void testCommentDashAtChunkBoundary() throws Exception {
+        // a lone '-' sitting on the 512-char chunk boundary. It is legal in
+        // comment content, but the speed path applied its trailing-dash fixup
+        // at the end of every chunk, so the boundary '-' was silently rewritten
+        // to a space and the saved comment no longer matched the source.
+        String data = repeat('a', 511) + "-" + repeat('b', 600);
+        XmlObject o = XmlObject.Factory.parse("<root><!--" + data + "--></root>");
+        String out = saveForSpeed(o);
+        XmlObject.Factory.parse(out);
+        assertTrue(out.contains(repeat('a', 511) + "-"));
+    }
+
+    @Test
     void testProcInstTerminatorAcrossChunkBoundary() throws Exception {
         // a '?>' that straddles the 512-char chunk boundary: '?' is the last char
         // of the first chunk, '>' the first char of the second. The per-chunk


### PR DESCRIPTION
Saving a comment longer than 512 chars with setSaveOptimizeForSpeed(true) lost a hyphen:

    in:  <!--aaa...(511)...a-bbb...b-->
    out: <!--aaa...(511)...a bbb...b-->

The '-' at index 511 sits on a chunk boundary. OptimizedForSpeedSaver emits comment text in 512-char chunks, and entitizeAndWriteCommentText ran its trailing-dash fixup at the end of every chunk, so a lone '-' that happened to fall on a boundary was rewritten to a space even though it was in the middle of the comment. The dash state was reset per chunk too.

That fixup is only wanted at the real end of the comment, to stop the text forming '--->' with the closing delimiter. TextSaver.entitizeComment already does that in a single pass. Threaded lastWasDash across the chunks and gated the fixup on the final chunk, matching the default saver and the pi emitter next to it.