### PR TITLE
throw loader exception on repeated string in StringPool.readFrom

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/schema/SchemaTypeSystemImpl.java
+++ b/src/main/java/org/apache/xmlbeans/impl/schema/SchemaTypeSystemImpl.java
@@ -725,7 +725,7 @@ public class SchemaTypeSystemImpl extends SchemaTypeLoaderBase implements Schema
                     String str = input.readLongUTF().intern();
                     int code = codeForString(str);
                     if (code != i) {
-                        throw new IllegalStateException();
+                        throw new SchemaTypeLoaderException("Repeated string pool entry", _name, _handle, SchemaTypeLoaderException.UNRECOGNIZED_INDEX_ENTRY);
                     }
                 }
             } catch (IOException e) {

--- a/src/test/java/org/apache/xmlbeans/impl/schema/StringPoolCodeTest.java
+++ b/src/test/java/org/apache/xmlbeans/impl/schema/StringPoolCodeTest.java
@@ -15,7 +15,13 @@
 package org.apache.xmlbeans.impl.schema;
 
 import org.apache.xmlbeans.SchemaTypeLoaderException;
+import org.apache.xmlbeans.impl.util.LongUTFDataInputStream;
+import org.apache.xmlbeans.impl.util.LongUTFDataOutputStream;
 import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -42,5 +48,23 @@ public class StringPoolCodeTest {
         // readUnsignedShortOrInt() falls back to a signed readInt() for the 0xffff
         // marker, so a negative code can reach stringForCode
         assertThrows(SchemaTypeLoaderException.class, () -> pool.stringForCode(-1));
+    }
+
+    @Test
+    void readFromRejectsRepeatedEntry() throws IOException {
+        // craft a string pool section that declares three entries but repeats a
+        // string; codeForString hands back the earlier code, so code != i in the
+        // populate loop, which must surface as the documented loader exception
+        // rather than a bare IllegalStateException
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        LongUTFDataOutputStream out = new LongUTFDataOutputStream(bos);
+        out.writeShortOrInt(3);
+        out.writeLongUTF("dup");
+        out.writeLongUTF("dup");
+        out.flush();
+
+        SchemaTypeSystemImpl.StringPool pool = new SchemaTypeSystemImpl.StringPool("handle", "name");
+        LongUTFDataInputStream in = new LongUTFDataInputStream(new ByteArrayInputStream(bos.toByteArray()));
+        assertThrows(SchemaTypeLoaderException.class, () -> pool.readFrom(in));
     }
 }


### PR DESCRIPTION
Fed a hand-corrupted .xsb at the schema loader to watch where it fell over:

    java.lang.IllegalStateException
        at org.apache.xmlbeans.impl.schema.SchemaTypeSystemImpl$StringPool.readFrom(SchemaTypeSystemImpl.java:728)
        at org.apache.xmlbeans.impl.schema.XsbReader.<init>(XsbReader.java:103)
        at org.apache.xmlbeans.impl.schema.SchemaTypeSystemImpl.resolveHandle(SchemaTypeSystemImpl.java:954)

readFrom fills the string pool by reading each entry and checking its assigned code equals the running index i. codeForString hands back the earlier code for a repeated string, so a pool that lists the same string twice makes code != i and trips a bare IllegalStateException with no message. readFrom only wraps IOException, so it leaks out as an undocumented runtime exception rather than the SchemaTypeLoaderException the loader is meant to raise; crackPointer catches only IOException too and sees the same thing while cracking a pointer file.

Threw SchemaTypeLoaderException the way stringForCode and the rest of the pool already report trouble. The size/emptiness check above it is a real internal invariant, so I left it. Valid files read back unchanged.