### PR TITLE
escape schema text copied into the generated java source

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/schema/SchemaTypeCodePrinter.java
+++ b/src/main/java/org/apache/xmlbeans/impl/schema/SchemaTypeCodePrinter.java
@@ -168,7 +168,7 @@ public final class SchemaTypeCodePrinter implements SchemaCodePrinter {
         }
         String result = qname.getLocalPart();
         if (qname.getNamespaceURI() != null) {
-            result += "(@" + qname.getNamespaceURI() + ")";
+            result += "(@" + javaCommentEscape(qname.getNamespaceURI()) + ")";
         }
         return result;
     }
@@ -345,7 +345,7 @@ public final class SchemaTypeCodePrinter implements SchemaCodePrinter {
         emit("/*");
         if (sType.getName() != null) {
             emit(" * XML Type:  " + sType.getName().getLocalPart());
-            emit(" * Namespace: " + sType.getName().getNamespaceURI());
+            emit(" * Namespace: " + javaCommentEscape(sType.getName().getNamespaceURI()));
         } else {
             QName thename = null;
 
@@ -362,7 +362,7 @@ public final class SchemaTypeCodePrinter implements SchemaCodePrinter {
             assert (thename != null);
 
             emit(" * Localname: " + thename.getLocalPart());
-            emit(" * Namespace: " + thename.getNamespaceURI());
+            emit(" * Namespace: " + javaCommentEscape(thename.getNamespaceURI()));
         }
         emit(" * Java type: " + sType.getFullJavaName());
         emit(" *");
@@ -504,13 +504,19 @@ public final class SchemaTypeCodePrinter implements SchemaCodePrinter {
     void printJavaDocBody(String doc) throws IOException{
         // add some poor mans code injection protection
         // this is not protecting against annotation based RCEs like CVE-2018-16621
-        String docClean = doc.trim()
-                .replace("\t", "")
-                .replace("*/", "* /");
+        String docClean = javaCommentEscape(doc.trim().replace("\t", ""));
 
         for (String s : docClean.split("[\\n\\r]+")) {
             emit(" * " + s);
         }
+    }
+
+    public static String javaCommentEscape(String str)
+    {
+        // forbidden: */, and the backslash of a unicode escape - those are decoded
+        // before comments are recognized (JLS 3.3), so an escaped */ ends the
+        // comment too and the rest of the schema text is compiled as code
+        return str.replace("\\", "\\\\").replace("*/", "* /");
     }
 
     public static String javaStringEscape(String str)
@@ -1427,7 +1433,7 @@ public final class SchemaTypeCodePrinter implements SchemaCodePrinter {
         for (SchemaProperty prop : properties) {
             final QName name = prop.getName();
             propMap.put(prop, new Identifier(propMap.size()));
-            emit("new QName(\"" + name.getNamespaceURI() + "\", \"" + name.getLocalPart() + "\"),");
+            emit("new QName(\"" + javaStringEscape(name.getNamespaceURI()) + "\", \"" + javaStringEscape(name.getLocalPart()) + "\"),");
             countQSet = Math.max(countQSet, (prop.acceptedNames() == null ? 0 : prop.acceptedNames().length));
         }
         outdent();
@@ -1444,7 +1450,7 @@ public final class SchemaTypeCodePrinter implements SchemaCodePrinter {
                     emit("QNameSet.forArray( new QName[] { ");
                     indent();
                     for (QName qname : qnames) {
-                        emit("new QName(\"" + qname.getNamespaceURI() + "\", \"" + qname.getLocalPart() + "\"),");
+                        emit("new QName(\"" + javaStringEscape(qname.getNamespaceURI()) + "\", \"" + javaStringEscape(qname.getLocalPart()) + "\"),");
                     }
                     outdent();
                     emit("}),");

--- a/src/test/java/compile/scomp/checkin/CompilationTests.java
+++ b/src/test/java/compile/scomp/checkin/CompilationTests.java
@@ -420,6 +420,31 @@ public class CompilationTests {
         assertTrue(act.contains("* / heck, I'm smart"));
     }
 
+    @Test
+    void schemaTextIsNotCompiledAsCode() throws Exception {
+        deltree(xbeanOutput("compile/scomp/codeinject"));
+        File srcdir = xbeanOutput("compile/scomp/codeinject/src");
+        File classesdir = xbeanOutput("compile/scomp/codeinject/classes");
+        Parameters params = new Parameters();
+        params.setXsdFiles(xbeanCase("schemacompiler/codeinject.xsd"));
+        params.setSrcDir(srcdir);
+        params.setClassesDir(classesdir);
+        params.setName("codeinject");
+        params.setCopyAnn(true);
+        assertTrue(SchemaCompiler.compile(params), "generated sources didn't compile");
+
+        // the quote in the target namespace has to stay inside the string literal
+        Path p = new File(srcdir, "codeinjectQ/impl/TImpl.java").toPath();
+        String act = new String(Files.readAllBytes(p), StandardCharsets.UTF_8);
+        assertTrue(act.contains("new QName(\"codeinject\\\"q\", \"single\")"), "namespace not escaped");
+
+        // the unicode escape in the documentation must not close the javadoc comment
+        try (Stream<Path> s = Files.walk(classesdir.toPath())) {
+            assertFalse(s.anyMatch(f -> "Pwned.class".equals(f.getFileName().toString())),
+                "class injected through the schema documentation");
+        }
+    }
+
     //TESTENV:
 
     private static void dumpErrors(List<XmlError> errors, PrintWriter out) {

--- a/src/test/resources/xbean/compile/scomp/schemacompiler/codeinject.xsd
+++ b/src/test/resources/xbean/compile/scomp/schemacompiler/codeinject.xsd
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- Copyright 2004 The Apache Software Foundation
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License. -->
+
+<!-- the target namespace carries a quote, which has to stay inside the generated
+     QName string literal, and the documentation carries a unicode escape, which
+     javac decodes to */ before it looks for comments -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns:tns="codeinject&quot;q"
+        targetNamespace="codeinject&quot;q"
+        elementFormDefault="qualified">
+
+    <xs:complexType name="T">
+        <xs:annotation>
+            <xs:documentation>a doc \u002a\u002f class Pwned {} /**</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="single" type="xs:string"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:element name="root" type="tns:T"/>
+</xs:schema>


### PR DESCRIPTION
printStaticFields writes the property qnames straight into a java string literal and printJavaDocBody only filters a literal `*/`, so a target namespace carrying a double quote, or documentation carrying a unicode escape for `*/`, breaks out of the generated source and gets arbitrary code compiled into the binding classes; both are escaped now, the qname sites with the javaStringEscape helper that already sits beside them.