### PR TITLE
fix boundary and performance issues in MathUtil conversions

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/util/MathUtil.java
+++ b/src/main/java/org/apache/xmlbeans/impl/util/MathUtil.java
@@ -34,7 +34,8 @@ public class MathUtil {
         if (Float.isInfinite(f)) {
             throw new IllegalArgumentException("Cannot convert infinity to int");
         }
-        if (f > Integer.MAX_VALUE || f < Integer.MIN_VALUE) {
+        // compare as double: widening Integer.MAX_VALUE to float rounds it up to 2^31
+        if ((double) f > Integer.MAX_VALUE || (double) f < Integer.MIN_VALUE) {
             throw new IllegalArgumentException("Value out of range: " + f);
         }
         return (int) f;
@@ -101,7 +102,7 @@ public class MathUtil {
 
     /**
      * @param s string to parse
-     * @return valid Float
+     * @return valid float
      * @throws NumberFormatException if parse fails
      * @throws IllegalArgumentException if string is too long
      * @throws NullPointerException if string is null
@@ -130,7 +131,7 @@ public class MathUtil {
 
     /**
      * @param s string to parse
-     * @return valid float
+     * @return valid double
      * @throws NumberFormatException if parse fails
      * @throws IllegalArgumentException if string is too long
      * @throws NullPointerException if string is null
@@ -142,7 +143,7 @@ public class MathUtil {
     /**
      * @param s string to parse
      * @param maxNumberOfChars maximum number of characters allowed in the string
-     * @return valid float
+     * @return valid double
      * @throws NumberFormatException if parse fails
      * @throws IllegalArgumentException if string is too long
      * @throws NullPointerException if string is null
@@ -198,12 +199,22 @@ public class MathUtil {
      * @throws NullPointerException if value is null
      */
     public static BigInteger toBigInteger(BigDecimal value) {
+        if (value == null) {
+            throw new NullPointerException("Cannot convert null to BigInteger");
+        }
         BigDecimal normalized = value.stripTrailingZeros();
         int integerDigits = normalized.precision() - normalized.scale();
+        // the scale check is not redundant: for a very negative scale (eg 1E+2147483647) the
+        // subtraction above overflows and integerDigits comes out negative
         if (integerDigits > DEFAULT_MAX_NUMBER_CHARS || normalized.scale() < -DEFAULT_MAX_NUMBER_CHARS) {
             throw new IllegalArgumentException(
                     "BigDecimal magnitude too large to convert safely: approx "
                             + integerDigits + " integer digits (limit " + DEFAULT_MAX_NUMBER_CHARS + ")");
+        }
+        if (integerDigits <= 0) {
+            // abs(value) is less than 1, so it truncates to zero - avoid BigDecimal.toBigInteger()
+            // computing 10^scale, which is very expensive for a large scale (eg 1E-10000000)
+            return BigInteger.ZERO;
         }
         return normalized.toBigInteger();
     }

--- a/src/test/java/org/apache/xmlbeans/impl/util/TestMathUtil.java
+++ b/src/test/java/org/apache/xmlbeans/impl/util/TestMathUtil.java
@@ -20,9 +20,11 @@ import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.Duration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 public class TestMathUtil {
     @Test
@@ -51,5 +53,61 @@ public class TestMathUtil {
         assertThrows(IllegalArgumentException.class, () -> MathUtil.toLong(expected));
         BigDecimal expected2 = BigDecimal.valueOf(Long.MIN_VALUE).subtract(BigDecimal.ONE);
         assertThrows(IllegalArgumentException.class, () -> MathUtil.toLong(expected2));
+    }
+
+    @Test
+    public void testToBigIntegerNull() {
+        assertThrows(NullPointerException.class, () -> MathUtil.toBigInteger(null));
+        assertThrows(NullPointerException.class, () -> MathUtil.toLong(null));
+        assertThrows(NullPointerException.class, () -> MathUtil.toInt(null));
+    }
+
+    @Test
+    public void testToBigIntegerSmallValuesTruncateToZero() {
+        assertEquals(BigInteger.ZERO, MathUtil.toBigInteger(new BigDecimal("0.5")));
+        assertEquals(BigInteger.ZERO, MathUtil.toBigInteger(new BigDecimal("-0.999")));
+        assertEquals(BigInteger.ZERO, MathUtil.toBigInteger(BigDecimal.ZERO));
+        assertEquals(BigInteger.ONE, MathUtil.toBigInteger(new BigDecimal("1.5")));
+    }
+
+    @Test
+    public void testToBigIntegerSmallExponent() {
+        // BigDecimal.toBigInteger() would compute 10^10000000 here, taking seconds
+        assertTimeoutPreemptively(Duration.ofSeconds(2), () ->
+                assertEquals(BigInteger.ZERO, MathUtil.toBigInteger(new BigDecimal("1E-10000000"))));
+    }
+
+    @Test
+    public void testToBigIntegerMaxNegativeScale() {
+        BigDecimal value = new BigDecimal("1E+2147483647");
+        assertThrows(IllegalArgumentException.class, () -> MathUtil.toBigInteger(value));
+    }
+
+    @Test
+    public void testSafeFloatToInt() {
+        assertEquals(1, MathUtil.safeFloatToInt(1.75f));
+        assertEquals(-1, MathUtil.safeFloatToInt(-1.75f));
+        assertEquals(Integer.MIN_VALUE, MathUtil.safeFloatToInt(Integer.MIN_VALUE));
+    }
+
+    @Test
+    public void testSafeFloatToIntWithValueOutOfRange() {
+        // 2^31 is the nearest float above Integer.MAX_VALUE and must not be accepted
+        assertThrows(IllegalArgumentException.class, () -> MathUtil.safeFloatToInt(2147483648f));
+        assertThrows(IllegalArgumentException.class, () -> MathUtil.safeFloatToInt(-2147483904f));
+        assertThrows(IllegalArgumentException.class, () -> MathUtil.safeFloatToInt(Float.MAX_VALUE));
+        assertThrows(IllegalArgumentException.class, () -> MathUtil.safeFloatToInt(Float.NaN));
+        assertThrows(IllegalArgumentException.class, () -> MathUtil.safeFloatToInt(Float.POSITIVE_INFINITY));
+    }
+
+    @Test
+    public void testSafeDoubleToInt() {
+        assertEquals(1, MathUtil.safeDoubleToInt(1.75));
+        assertEquals(Integer.MAX_VALUE, MathUtil.safeDoubleToInt(Integer.MAX_VALUE));
+        assertEquals(Integer.MIN_VALUE, MathUtil.safeDoubleToInt(Integer.MIN_VALUE));
+        assertThrows(IllegalArgumentException.class, () -> MathUtil.safeDoubleToInt(2147483648d));
+        assertThrows(IllegalArgumentException.class, () -> MathUtil.safeDoubleToInt(-2147483649d));
+        assertThrows(IllegalArgumentException.class, () -> MathUtil.safeDoubleToInt(Double.NaN));
+        assertThrows(IllegalArgumentException.class, () -> MathUtil.safeDoubleToInt(Double.NEGATIVE_INFINITY));
     }
 }


### PR DESCRIPTION
Three issues in `MathUtil`, each covered by a new test.

**`safeFloatToInt` accepted `2147483648f`.** Widening `Integer.MAX_VALUE` to `float` rounds it up to `2^31`, so `f > Integer.MAX_VALUE` was false for exactly `2^31` and the `(int)` cast silently saturated to `2147483647` — the wrong answer from a method whose job is to reject out-of-range input. Comparing as `double` fixes it. The lower bound was already correct, since `-2^31` is exactly representable, and `safeDoubleToInt` was never affected.

**`toBigInteger` guarded a large negative scale but not a large positive one.** A value like `1E-10000000` has `integerDigits == -9999999` and `scale == +10000000`, so neither existing condition tripped and `BigDecimal.toBigInteger()` was reached. That calls `setScale(0)`, which computes `10^scale`: measured at just over 4 seconds to return `0` from a 12-character input, and at larger exponents it throws `ArithmeticException: BigInteger would overflow supported range` instead of the documented `IllegalArgumentException`. The string passes `parseAsBigDecimal`'s length limit easily, and the path is reachable from parsed content via `JavaDecimalHolder` / `XmlObjectBase.getBigIntegerValue()`. Any such value truncates to zero, so return `BigInteger.ZERO` directly — which also makes every sub-1 conversion cheaper.

**`toBigInteger` had no explicit null check**, unlike every other method here. It already threw `NullPointerException` from `stripTrailingZeros()`, so this is consistency rather than a behaviour change; `toLong` and `toInt` inherit it.

Also added a comment on the existing `scale() < -DEFAULT_MAX_NUMBER_CHARS` condition, which reads as redundant but is not: for `1E+2147483647` the `precision() - scale()` subtraction overflows to `Integer.MIN_VALUE` and only the scale check catches it. And corrected a few copy-pasted javadoc `@return` types (`parseAsDouble` documented `float`).

Ran the `impl.util` and `impl.values` tests locally — all pass. Leaving the full suite to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)