### PR TITLE
Fix printDecimal regression for decimal values wider than a long

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/util/XsTypeConverter.java
+++ b/src/main/java/org/apache/xmlbeans/impl/util/XsTypeConverter.java
@@ -279,7 +279,8 @@ public final class XsTypeConverter {
         // The following code comes from Apache Harmony
         String intStr = value.unscaledValue().toString();
         int scale = value.scale();
-        if (scale == 0 || (MathUtil.toLong(value) == 0 && scale < 0)) {
+        // the second branch only needs a zero check, as in the original Harmony code
+        if (scale == 0 || (value.signum() == 0 && scale < 0)) {
             return intStr;
         }
 

--- a/src/test/java/misc/checkin/XsTypeConverterTest.java
+++ b/src/test/java/misc/checkin/XsTypeConverterTest.java
@@ -22,6 +22,8 @@ import org.apache.xmlbeans.impl.util.XsTypeConverter;
 import org.apache.xmlbeans.impl.values.XmlValueOutOfRangeException;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigDecimal;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -308,5 +310,28 @@ public class XsTypeConverterTest {
         javax.xml.namespace.QName empty = XsTypeConverter.lexQName("", errors, ctx);
         assertEquals("", empty.getLocalPart());
         assertEquals(1, errors.size());
+    }
+
+    @Test
+    void printDecimalHandlesValuesWiderThanLong() {
+        assertEquals("123456789012345678901234567890.5",
+            XsTypeConverter.printDecimal(new BigDecimal("123456789012345678901234567890.5")));
+        assertEquals("-123456789012345678901234567890.5",
+            XsTypeConverter.printDecimal(new BigDecimal("-123456789012345678901234567890.5")));
+    }
+
+    @Test
+    void printDecimalHandlesNegativeScaleWiderThanLong() {
+        // stripTrailingZeros() and BigDecimal.valueOf(unscaled, negativeScale) both
+        // produce negative-scale values, which reach printDecimal via setBigDecimalValue.
+        assertEquals("100000000000000000000", XsTypeConverter.printDecimal(new BigDecimal("1E+20")));
+        assertEquals("-100000000000000000000", XsTypeConverter.printDecimal(new BigDecimal("-1E+20")));
+        assertEquals("100", XsTypeConverter.printDecimal(new BigDecimal("1E+2")));
+    }
+
+    @Test
+    void printDecimalHandlesZeroWithScale() {
+        assertEquals("0", XsTypeConverter.printDecimal(new BigDecimal("0E+5")));
+        assertEquals("0.00000", XsTypeConverter.printDecimal(new BigDecimal("0E-5")));
     }
 }


### PR DESCRIPTION
Regression introduced in 5.4.0: printing any xsd:decimal that has a non-zero scale and does not fit into a long throws IllegalArgumentException("Value can't be converted to long"). 5.3.0 prints the same value correctly.

XsTypeConverter.printDecimal calls MathUtil.toLong(value) as the left operand of an && whose right operand is the "scale < 0" guard. Java evaluates && left to right, so toLong() runs for every value with a non-zero scale. Its result only matters when the scale is negative - in which case the value is integral and always fits into a long - but by then the exception has already been thrown.

5.3.0 used BigDecimal.longValue() on that line, which truncates silently instead of throwing, so the condition was simply false and printing proceeded. MathUtil was added in 5.4.0 and toLong() replaced longValue() here.

Swapping the operands restores the old behaviour without changing the semantics.

Seen in the wild as a WSDL2Java code generation failure: xmlbeans could no longer save a compiled schema type system containing a high-precision decimal.