### PR TITLE
Bound a decimal by the digits it denotes, not just its characters

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/util/MathUtil.java
+++ b/src/main/java/org/apache/xmlbeans/impl/util/MathUtil.java
@@ -70,7 +70,8 @@ public class MathUtil {
      * @param maxNumberOfChars maximum number of characters allowed in the string
      * @return valid BigDecimal
      * @throws NumberFormatException if parse fails
-     * @throws IllegalArgumentException if string is too long
+     * @throws IllegalArgumentException if the string is too long, or denotes more digits
+     * than it has characters to spare
      * @throws NullPointerException if string is null
      */
     public static BigDecimal parseAsBigDecimal(String s, int maxNumberOfChars) {
@@ -80,7 +81,30 @@ public class MathUtil {
         if (s.length() > maxNumberOfChars) {
             throw new IllegalArgumentException("Number has more than " + maxNumberOfChars + " characters");
         }
-        return new BigDecimal(s);
+        final BigDecimal value = new BigDecimal(s);
+        final long digits = plainLength(value);
+        if (digits > maxNumberOfChars) {
+            throw new IllegalArgumentException("Number denotes " + digits + " digits, more than the "
+                + maxNumberOfChars + " characters allowed");
+        }
+        return value;
+    }
+
+    /**
+     * The number of characters it takes to write the value out without an exponent, which
+     * is the form xsd:decimal allows and so the form the maximum number of characters is
+     * meant to bound. Only an exponent can make this exceed the length of the lexical
+     * value it was parsed from, and an exponent is a handful of characters: the 13
+     * characters of "1E+2000000000" denote two billion digits.
+     */
+    private static long plainLength(BigDecimal value) {
+        final int scale = value.scale();
+        final int precision = value.precision();
+        return scale <= 0
+            // integer digits, ie the significant digits plus the trailing zeros
+            ? (long) precision - scale
+            // the digits either side of the decimal point, plus the point itself
+            : Math.max(precision, (long) scale + 1) + 1;
     }
 
     /**

--- a/src/test/java/misc/checkin/MaxNumberOfCharsTest.java
+++ b/src/test/java/misc/checkin/MaxNumberOfCharsTest.java
@@ -184,6 +184,37 @@ public class MaxNumberOfCharsTest {
     }
 
     @Test
+    public void testDecimalRejectsExponentDenotingTooManyDigits() throws XmlException {
+        // "1E+2000000000" is 13 characters, well under any limit, but denotes two billion
+        // digits. It is not a valid xsd:decimal lexical value in the first place, and the
+        // limit has to catch it whether or not the value is validated on set.
+        XmlDecimal value = XmlDecimal.Factory.parse(frag("1E+2000000000"));
+        assertThrows(XmlValueOutOfRangeException.class, value::getBigDecimalValue);
+
+        XmlOptions exponent = maxChars(XmlOptions.DEFAULT_MAX_NUMBER_CHARS);
+        exponent.setLoadAllowDecimalExponent(true);
+        XmlDecimal allowed = XmlDecimal.Factory.parse(frag("1E+2000000000"), exponent);
+        assertThrows(XmlValueOutOfRangeException.class, allowed::getBigDecimalValue);
+
+        XmlDecimal negative = XmlDecimal.Factory.parse(frag("1E-2000000000"), exponent);
+        assertThrows(XmlValueOutOfRangeException.class, negative::getBigDecimalValue);
+    }
+
+    @Test
+    public void testDecimalStillAcceptsExponentWithinLimit() throws XmlException {
+        XmlOptions exponent = maxChars(XmlOptions.DEFAULT_MAX_NUMBER_CHARS);
+        exponent.setLoadAllowDecimalExponent(true);
+
+        XmlDecimal value = XmlDecimal.Factory.parse(frag("1E+20"), exponent);
+        assertEquals(new BigDecimal("1E+20"), value.getBigDecimalValue());
+
+        XmlOptions raised = maxChars(4096);
+        raised.setLoadAllowDecimalExponent(true);
+        XmlDecimal wide = XmlDecimal.Factory.parse(frag("1E+2000"), raised);
+        assertEquals(2001, wide.getBigDecimalValue().precision() - wide.getBigDecimalValue().scale());
+    }
+
+    @Test
     public void testDecimalHashCodeIgnoresLimit() {
         // hashCode() must not throw, whatever the limit is, and must stay aligned with
         // the hash of the same value held as an xsd:integer

--- a/src/test/java/org/apache/xmlbeans/impl/util/TestMathUtil.java
+++ b/src/test/java/org/apache/xmlbeans/impl/util/TestMathUtil.java
@@ -134,6 +134,37 @@ public class TestMathUtil {
     }
 
     @Test
+    public void testParseAsBigDecimalBoundsDigitsNotJustCharacters() {
+        // an exponent is a handful of characters denoting arbitrarily many digits, so the
+        // limit has to apply to what the value denotes, not only to what was written
+        assertThrows(IllegalArgumentException.class, () -> MathUtil.parseAsBigDecimal("1E+2000000000"));
+        assertThrows(IllegalArgumentException.class, () -> MathUtil.parseAsBigDecimal("1E-2000000000"));
+        assertThrows(IllegalArgumentException.class, () -> MathUtil.parseAsBigDecimal("1E+2000"));
+        assertThrows(IllegalArgumentException.class, () -> MathUtil.parseAsBigDecimal("1E+9", 4));
+
+        // within the limit an exponent is still accepted, and a raised limit still raises it
+        assertEquals(new BigDecimal("1E+20"), MathUtil.parseAsBigDecimal("1E+20"));
+        assertEquals(new BigDecimal("1E+2000"), MathUtil.parseAsBigDecimal("1E+2000", 4096));
+    }
+
+    @Test
+    public void testParseAsBigDecimalAcceptsPlainValues() {
+        // without an exponent the digit count cannot exceed the length of the lexical
+        // value, so the new bound never rejects what the length check accepts
+        assertEquals(new BigDecimal("123.45"), MathUtil.parseAsBigDecimal("123.45"));
+        assertEquals(new BigDecimal("-0.001"), MathUtil.parseAsBigDecimal("-0.001"));
+        assertEquals(new BigDecimal("0.10"), MathUtil.parseAsBigDecimal("0.10"));
+        assertEquals(BigDecimal.ZERO, MathUtil.parseAsBigDecimal("0"));
+
+        StringBuilder sb = new StringBuilder("1");
+        for (int i = 1; i < XmlOptions.DEFAULT_MAX_NUMBER_CHARS; i++) {
+            sb.append('0');
+        }
+        assertEquals(XmlOptions.DEFAULT_MAX_NUMBER_CHARS,
+            MathUtil.parseAsBigDecimal(sb.toString()).precision());
+    }
+
+    @Test
     public void testSafeDoubleToInt() {
         assertEquals(1, MathUtil.safeDoubleToInt(1.75));
         assertEquals(Integer.MAX_VALUE, MathUtil.safeDoubleToInt(Integer.MAX_VALUE));


### PR DESCRIPTION
Follow-up to #97. That PR hardened the paths that *consume* an oversized decimal; this one stops one being created from a document in the first place.

### The gap

`maxNumberOfCharsForNumbers` is documented as bounding the size of numbers read out of a document, but it only checked the length of the lexical value. An exponent is a handful of characters denoting arbitrarily many digits:

```
parse <xml-fragment>1E+2000000000</xml-fragment> as XmlDecimal, default options
  -> stored, scale=-2000000000 precision=1
```

13 characters, under any limit, producing a `BigDecimal` that is trivial to hold and catastrophic to expand. No option is needed to get there: `Factory.parse` doesn't validate on set, so `validateLexical` — the check that rejects an exponent — never runs. `setLoadAllowDecimalExponent(true)` reaches it by the documented route.

### Why the check is safe

Exponent notation isn't part of the `xsd:decimal` lexical space at all; it belongs to `float`/`double`. XSD leaves the value space unbounded and only requires that a minimally conforming processor support at least 18 digits (Part 2 §3.2.3), so an implementation limit well above that is conformant either way.

The consequence that matters here: for conformant input the digit count is bounded by the length of the lexical value, so a bound on digits can never reject something the existing length check accepts. It fires only for exponent forms that were never valid `xsd:decimal` — which is why `testParseAsBigDecimalAcceptsPlainValues` can assert the plain forms are untouched.

### The change

Applied in `MathUtil.parseAsBigDecimal`, the single point that both `JavaDecimalHolder.set_text` and `JavaDecimalHolderEx.set_text` go through, along with `validateLexical`'s exponent branch and `Validator`. The bound is the length of the value written out without an exponent, which is the form `xsd:decimal` allows and therefore the form the limit is meant to bound:

```java
return scale <= 0
    ? (long) precision - scale                        // integer digits
    : Math.max(precision, (long) scale + 1) + 1;      // digits either side of the point
```

Both directions are covered — `1E-2000000000` would otherwise make `printDecimal` allocate a two-billion-character `StringBuilder`.

A raised limit still raises the bound: `1E+2000` is rejected at the default 1024 and accepted at `maxChars(4096)`.

### Still open

`setBigDecimalValue` remains unbounded, so a value like this can still be constructed programmatically. That's why #97's guards in `value_hash_code` and `to_BigInteger` stay: they now defend a path that a document can no longer reach, rather than the one it could.

### Tests

Two in `TestMathUtil` (the bound applies to denoted digits, in both exponent directions and under raised and lowered limits; plain lexical forms are unaffected) and two in `MaxNumberOfCharsTest` (a document is rejected with and without the exponent option, and an exponent within the limit still parses).

Full suite: 3086 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
