### PR TITLE
Stop xsd2inst building digit-facet bounds as strings

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/xsd2inst/SampleXmlUtil.java
+++ b/src/main/java/org/apache/xmlbeans/impl/xsd2inst/SampleXmlUtil.java
@@ -382,6 +382,24 @@ public class SampleXmlUtil {
         return result;
     }
 
+    /**
+     * The number of digits before the decimal point, which is the same for every
+     * representation of a value.
+     */
+    private static long integerDigits(BigDecimal value) {
+        return (long) value.precision() - value.scale();
+    }
+
+    /**
+     * The largest value that fits in the given number of digits, ie 999...9. Computed as
+     * 10^digits - 1 rather than built as a string of nines, which the maximum number of
+     * characters allowed for a number rejects once the schema asks for more digits than
+     * that - xsd:totalDigits is a positiveInteger and has no such ceiling.
+     */
+    private static BigDecimal widestValue(int digits) {
+        return BigDecimal.TEN.pow(digits).subtract(BigDecimal.ONE);
+    }
+
     private String formatDecimal(String start, SchemaType sType) {
         BigDecimal result = MathUtil.parseAsBigDecimal(start);
         XmlDecimal xmlD;
@@ -411,19 +429,22 @@ public class SampleXmlUtil {
         if (xmlD != null) {
             totalDigits = MathUtil.toInt(xmlD.getBigDecimalValue());
 
-            StringBuilder sb = new StringBuilder(totalDigits);
-            for (int i = 0; i < totalDigits; i++) {
-                sb.append('9');
+            // the widest value the facet allows can only narrow a bound that is at least
+            // as wide, so it is computed only when it can bind - which also keeps it away
+            // from a totalDigits far larger than any bound the schema declares
+            if (max != null && integerDigits(max) >= totalDigits) {
+                BigDecimal digitsLimit = widestValue(totalDigits);
+                if (max.compareTo(digitsLimit) > 0) {
+                    max = digitsLimit;
+                    maxInclusive = true;
+                }
             }
-            BigDecimal digitsLimit = MathUtil.parseAsBigDecimal(sb.toString());
-            if (max != null && max.compareTo(digitsLimit) > 0) {
-                max = digitsLimit;
-                maxInclusive = true;
-            }
-            digitsLimit = digitsLimit.negate();
-            if (min != null && min.compareTo(digitsLimit) < 0) {
-                min = digitsLimit;
-                minInclusive = true;
+            if (min != null && integerDigits(min) >= totalDigits) {
+                BigDecimal digitsLimit = widestValue(totalDigits).negate();
+                if (min.compareTo(digitsLimit) < 0) {
+                    min = digitsLimit;
+                    minInclusive = true;
+                }
             }
         }
 
@@ -441,12 +462,8 @@ public class SampleXmlUtil {
         } else {
             fractionDigits = MathUtil.toInt(xmlD.getBigDecimalValue());
             if (fractionDigits > 0) {
-                StringBuilder sb = new StringBuilder("0.");
-                for (int i = 1; i < fractionDigits; i++) {
-                    sb.append('0');
-                }
-                sb.append('1');
-                increment = MathUtil.parseAsBigDecimal(sb.toString());
+                // 1 shifted fractionDigits places right, ie 0.00...1
+                increment = BigDecimal.ONE.scaleByPowerOfTen(-fractionDigits);
             } else {
                 increment = BigDecimal.ONE;
             }

--- a/src/test/java/tools/xsd2inst/checkin/Xsd2InstTest.java
+++ b/src/test/java/tools/xsd2inst/checkin/Xsd2InstTest.java
@@ -62,6 +62,50 @@ public class Xsd2InstTest {
         }
     }
 
+    private static String decimalSchema(String facets) {
+        return "<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema'>" +
+            "<xs:element name='value' type='constrainedDecimal'/>" +
+            "<xs:simpleType name='constrainedDecimal'>" +
+            "<xs:restriction base='xs:decimal'>" + facets + "</xs:restriction>" +
+            "</xs:simpleType></xs:schema>";
+    }
+
+    private static String sampleFor(String facets) throws Exception {
+        XmlObject xsd = XmlObject.Factory.parse(decimalSchema(facets));
+        SchemaTypeSystem sts = XmlBeans.compileXsd(new XmlObject[]{xsd},
+            XmlBeans.getBuiltinTypeSystem(), new XmlOptions());
+        return SampleXmlUtil.createSampleForType(sts.globalElements()[0]);
+    }
+
+    @Test
+    void testDigitFacetsWiderThanTheNumberLengthLimit() throws Exception {
+        // xsd:totalDigits and xsd:fractionDigits are positiveInteger and so have no
+        // ceiling of their own; building the bounds they imply as strings of digits ran
+        // them into the maximum number of characters allowed for a number
+        String result = sampleFor("<xs:totalDigits value='2000'/>");
+        assertTrue(result.contains("<value>"), result);
+        try (InputStream docStream = new ByteArrayInputStream(result.getBytes(StandardCharsets.UTF_8))) {
+            assertNotNull(DocumentHelper.readDocument(new XmlOptions(), docStream));
+        }
+
+        result = sampleFor("<xs:fractionDigits value='1500'/>");
+        assertTrue(result.contains("<value>"), result);
+        try (InputStream docStream = new ByteArrayInputStream(result.getBytes(StandardCharsets.UTF_8))) {
+            assertNotNull(DocumentHelper.readDocument(new XmlOptions(), docStream));
+        }
+    }
+
+    @Test
+    void testTotalDigitsStillNarrowsTheBounds() throws Exception {
+        // the sample seed for a decimal is 1000.00, which xsd:totalDigits has to pull
+        // down to the widest value the facet allows
+        String result = sampleFor("<xs:maxInclusive value='999999'/><xs:totalDigits value='3'/>");
+        assertTrue(result.contains("<value>999</value>"), result);
+
+        String unconstrained = sampleFor("<xs:maxInclusive value='999999'/>");
+        assertTrue(unconstrained.contains("<value>1000.00</value>"), unconstrained);
+    }
+
     @Test
     void testSampleXmlUtil() throws Exception {
         XmlObject xobj;


### PR DESCRIPTION
Branched from trunk, independent of #98.

### The bug

`SampleXmlUtil.formatDecimal` derived both digit-facet bounds by building a string and parsing it back — `xsd:totalDigits` as that many nines, `xsd:fractionDigits` as `"0.00...1"`. Both facets are `positiveInteger` with no ceiling of their own, so as soon as a schema asks for more digits than `maxNumberOfCharsForNumbers` allows, `parseAsBigDecimal` rejects the string the method just built:

```
IllegalArgumentException: Number has more than 1024 characters
```

and `xsd2inst` cannot generate a sample for the schema at all. 5.3.0 used `new BigDecimal(...)` here and was unaffected; the limit arrived in 5.4.0.

A minimal reproducer — nothing else in the schema:

```xml
<xs:simpleType name="constrainedDecimal">
  <xs:restriction base="xs:decimal">
    <xs:totalDigits value="2000"/>
  </xs:restriction>
</xs:simpleType>
```

The `fractionDigits` branch fails the same way at 1023.

### The fix

Compute both values instead of spelling them out:

- `10^totalDigits - 1` for the widest value the facet allows;
- `BigDecimal.ONE.scaleByPowerOfTen(-fractionDigits)` for the increment, which only sets a scale and expands nothing.

The `totalDigits` bound can only narrow a `min`/`max` that is at least as wide, so it is now computed only when it can actually bind. That is what keeps `10^n` away from a `totalDigits` far larger than any bound the schema declares — the previous code built its string of nines unconditionally, even when no `min` or `max` facet existed for it to constrain.

Behaviour for schemas within the limit is unchanged: `totalDigits` still pulls the seed value down to the widest value it permits.

### Tests

`testDigitFacetsWiderThanTheNumberLengthLimit` covers both facets past the limit — it fails on trunk with the exception above. `testTotalDigitsStillNarrowsTheBounds` pins the normal case (seed `1000.00`, `totalDigits=3` → `999`) and passes both before and after, so it guards the semantics rather than the fix.

Full suite: 3084 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
