### PR TITLE
Let the configured number limit reach schema compilation

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/schema/SchemaTypeSystemCompiler.java
+++ b/src/main/java/org/apache/xmlbeans/impl/schema/SchemaTypeSystemCompiler.java
@@ -226,8 +226,11 @@ public class SchemaTypeSystemCompiler {
             // load all the xsd files into it
             if (validate) {
                 XmlOptions validateOptions = new XmlOptions().setErrorListener(errorWatcher);
-                if (options != null && options.isValidateTreatLaxAsSkip()) {
-                    validateOptions.setValidateTreatLaxAsSkip();
+                if (options != null) {
+                    if (options.isValidateTreatLaxAsSkip()) {
+                        validateOptions.setValidateTreatLaxAsSkip();
+                    }
+                    validateOptions.setMaxNumberOfCharsForNumbers(options.getMaxNumberOfCharsForNumbers());
                 }
                 for (Schema schema : schemas) {
                     if (schema.validate(validateOptions)) {

--- a/src/main/java/org/apache/xmlbeans/impl/schema/StscState.java
+++ b/src/main/java/org/apache/xmlbeans/impl/schema/StscState.java
@@ -106,6 +106,7 @@ public class StscState {
     private boolean _noAnn;
     private boolean _mdefAll;
     private String _sourceCodeEncoding ;
+    private int _maxNumberOfCharsForNumbers = XmlOptions.DEFAULT_MAX_NUMBER_CHARS;
     private final Set<String> _mdefNamespaces = buildDefaultMdefNamespaces();
     private EntityResolver _entityResolver;
     private File _schemasDir;
@@ -462,6 +463,7 @@ public class StscState {
                  !"true".equals(SystemProperties.getProperty("xmlbean.schemaannotations", "true"));
         _doingDownloads = options.isCompileDownloadUrls() ||
                           "true".equals(SystemProperties.getProperty("xmlbean.downloadurls", "false"));
+        _maxNumberOfCharsForNumbers = options.getMaxNumberOfCharsForNumbers();
         _sourceCodeEncoding = options.getCharacterEncoding();
         if (_sourceCodeEncoding == null || _sourceCodeEncoding.isEmpty()) {
             _sourceCodeEncoding = SystemProperties.getProperty("xmlbean.sourcecodeencoding");
@@ -536,6 +538,14 @@ public class StscState {
     // EXPERIMENTAL
     public String sourceCodeEncoding() {
         return _sourceCodeEncoding ;
+    }
+
+    /**
+     * The maximum number of characters a number in the schema being compiled may have,
+     * as configured by XmlOptions.setMaxNumberOfCharsForNumbers.
+     */
+    public int maxNumberOfCharsForNumbers() {
+        return _maxNumberOfCharsForNumbers;
     }
 
     /**

--- a/src/main/java/org/apache/xmlbeans/impl/schema/StscTranslator.java
+++ b/src/main/java/org/apache/xmlbeans/impl/schema/StscTranslator.java
@@ -1509,10 +1509,13 @@ public class StscTranslator {
         if (value == null) {
             return null;
         }
-        String text = value.getStringValue();
+        // materialising the facet's text can fail in its own right, if the schema was
+        // loaded with a lower limit than the number it declares, so it is inside the try
+        String text = null;
         BigInteger bigInt;
         try {
-            bigInt = MathUtil.parseAsBigInteger(text);
+            text = value.getStringValue();
+            bigInt = MathUtil.parseAsBigInteger(text, StscState.get().maxNumberOfCharsForNumbers());
         } catch (Exception e) {
             StscState.get().error(XmlErrorCodes.INVALID_VALUE_DETAIL, new Object[]{text, "nonNegativeInteger", e.getMessage()}, value);
             return null;

--- a/src/main/java/org/apache/xmlbeans/impl/validator/Validator.java
+++ b/src/main/java/org/apache/xmlbeans/impl/validator/Validator.java
@@ -1110,8 +1110,20 @@ public final class Validator
                 }
 
                 if (errorState == _errorState) {
-                    _decimalValue = MathUtil.parseAsBigDecimal(value, _options.getMaxNumberOfCharsForNumbers());
-                    JavaDecimalHolderEx.validateValue(_decimalValue, type, _vc);
+                    BigDecimal parsed = null;
+                    try {
+                        parsed = MathUtil.parseAsBigDecimal(value, _options.getMaxNumberOfCharsForNumbers());
+                    } catch (IllegalArgumentException e) {
+                        // a number longer than the configured maximum is invalid input,
+                        // not a programming error - report it like any other bad value
+                        // rather than throwing out of validate()
+                        _vc.invalid(derivedFromInteger(type) ? XmlErrorCodes.INTEGER : XmlErrorCodes.DECIMAL,
+                            new Object[]{value});
+                    }
+                    if (parsed != null) {
+                        _decimalValue = parsed;
+                        JavaDecimalHolderEx.validateValue(_decimalValue, type, _vc);
+                    }
                 }
 
                 break;

--- a/src/test/java/misc/checkin/MaxNumberOfCharsTest.java
+++ b/src/test/java/misc/checkin/MaxNumberOfCharsTest.java
@@ -14,22 +14,30 @@
  */
 package misc.checkin;
 
+import org.apache.xmlbeans.SchemaTypeSystem;
 import org.apache.xmlbeans.SimpleValue;
+import org.apache.xmlbeans.XmlBeans;
 import org.apache.xmlbeans.XmlDecimal;
+import org.apache.xmlbeans.XmlError;
 import org.apache.xmlbeans.XmlException;
 import org.apache.xmlbeans.XmlInt;
 import org.apache.xmlbeans.XmlInteger;
 import org.apache.xmlbeans.XmlLong;
+import org.apache.xmlbeans.XmlObject;
 import org.apache.xmlbeans.XmlOptions;
 import org.apache.xmlbeans.impl.values.XmlValueOutOfRangeException;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * XmlOptions.setMaxNumberOfCharsForNumbers has to apply to values materialised from the
@@ -212,6 +220,46 @@ public class MaxNumberOfCharsTest {
         raised.setLoadAllowDecimalExponent(true);
         XmlDecimal wide = XmlDecimal.Factory.parse(frag("1E+2000"), raised);
         assertEquals(2001, wide.getBigDecimalValue().precision() - wide.getBigDecimalValue().scale());
+    }
+
+    @Test
+    public void testValidateReportsAnOverLongNumber() throws XmlException {
+        // validate() reports what is wrong with a document; a number past the limit is
+        // bad input like any other and must not come back as an exception
+        List<XmlError> errors = new ArrayList<>();
+        XmlInteger integer = XmlInteger.Factory.parse(frag(digits(2000)));
+        assertFalse(integer.validate(new XmlOptions().setErrorListener(errors)));
+        assertFalse(errors.isEmpty());
+
+        errors.clear();
+        XmlDecimal decimal = XmlDecimal.Factory.parse(frag(digits(2000) + ".5"));
+        assertFalse(decimal.validate(new XmlOptions().setErrorListener(errors)));
+        assertFalse(errors.isEmpty());
+    }
+
+    @Test
+    public void testSchemaCompileHonoursLimit() throws XmlException {
+        // the facet value is a number in the schema document, so the limit has to reach
+        // the validation and the facet handling that compilation does
+        String xsd = "<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema'>" +
+            "<xs:element name='value' type='boundedString'/>" +
+            "<xs:simpleType name='boundedString'><xs:restriction base='xs:string'>" +
+            "<xs:maxLength value='" + digits(2000) + "'/>" +
+            "</xs:restriction></xs:simpleType></xs:schema>";
+
+        XmlOptions raised = maxChars(4096);
+        SchemaTypeSystem sts = XmlBeans.compileXsd(
+            new XmlObject[]{XmlObject.Factory.parse(xsd, raised)}, XmlBeans.getBuiltinTypeSystem(), raised);
+        assertEquals(1, sts.globalElements().length);
+
+        // at the default limit the same schema is reported as invalid, not thrown out of
+        List<XmlError> errors = new ArrayList<>();
+        XmlOptions dflt = new XmlOptions().setErrorListener(errors);
+        XmlObject parsed = XmlObject.Factory.parse(xsd);
+        assertThrows(XmlException.class,
+            () -> XmlBeans.compileXsd(new XmlObject[]{parsed}, XmlBeans.getBuiltinTypeSystem(), dflt));
+        assertTrue(errors.stream().anyMatch(e -> e.getMessage().contains("Invalid integer value")),
+            errors.toString());
     }
 
     @Test


### PR DESCRIPTION
Started as the `StscTranslator.buildBigInt` item — parse the numeric facets of a schema under the configured limit rather than the hardcoded default. Tracing it showed `buildBigInt` was never even reached, and two paths on the way to it threw instead of reporting.

### 1. `buildBigInt` used the default limit — `StscTranslator:1515`

`totalDigits`, `maxLength` and the other numeric facets are numbers in a schema document, and schemas are input too — in `scomp`, `xsd2inst` and downloaded imports, not always trusted ones. `StscState.setOptions` already receives the `XmlOptions` and keeps a handful of fields, so `_maxNumberOfCharsForNumbers` joins them.

### 2. Schema validation dropped the options — `SchemaTypeSystemCompiler:228`

```java
XmlOptions validateOptions = new XmlOptions().setErrorListener(errorWatcher);
if (options != null && options.isValidateTreatLaxAsSkip()) { ... }
```

A fresh `XmlOptions` carrying the error listener and one flag, so the limit never reached the validation pass that runs over the schema documents. This is what made 1 unreachable: validation failed on the facet before compilation looked at it.

### 3. `validate()` threw instead of reporting — `Validator:1113`

Not schema-specific. `validateAtomicType` parsed the decimal outside the `ValidationContext`:

```
XmlInteger 2000-digit .validate() -> IllegalArgumentException: Number has more than 1024 characters
XmlDecimal 2000-digit .validate() -> IllegalArgumentException: Number has more than 1024 characters
XmlDouble  2000-digit .validate() -> returned false, 1 error
```

`xs:double` behaves correctly because `JavaDoubleHolderEx.validateLexical` takes the limit and reports through the context. The decimal branch never got the same treatment: the lexical check preceding it validates characters but not length, so nothing is reported and the parse throws. `validate()` is the method that says what is wrong with a document — a number past the limit is bad input like any other and now comes back as an error.

### 4. `buildBigInt` threw while materialising the facet — `StscTranslator:1512`

`value.getStringValue()` sat outside the method's own `try`, and it can fail in its own right: it triggers the lazy `set_text` on the facet's typed value under the schema document's limit. A schema loaded with a lower limit than the number it declares threw `XmlValueOutOfRangeException` out of `compileXsd`. Moved inside.

### Note on raising the limit

The limit is fixed when a document is loaded, so a schema has to be *parsed* with the raised options as well as compiled with them. Passing raised options only to `compileXsd` leaves the schema document itself on the default, and the facet is rejected when its text is materialised — now as a reported error rather than a thrown one. The tooling paths already pass one `XmlOptions` to both.

### Tests

`testValidateReportsAnOverLongNumber` covers 3 for `xs:integer` and `xs:decimal`. `testSchemaCompileHonoursLimit` covers 1 and 2 — a schema whose `maxLength` facet is 2000 digits compiles under `maxChars(4096)` and is reported invalid under the default.

Full suite: 3090 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
