### PR TITLE
Restore java_value fallbacks lost in the switch reordering

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/values/XmlObjectBase.java
+++ b/src/main/java/org/apache/xmlbeans/impl/values/XmlObjectBase.java
@@ -3081,9 +3081,10 @@ public abstract class XmlObjectBase implements TypeStoreUser, Serializable, XmlO
 
                     case SchemaType.SIZE_BIG_DECIMAL:
                         return base.getBigDecimalValue();
+
                     default:
                         assert (false) : "invalid numeric bit count";
-                        // fallthrough
+                        return base.getBigDecimalValue();
                 }
             }
             case SchemaType.BTC_ANY_URI:
@@ -3101,19 +3102,18 @@ public abstract class XmlObjectBase implements TypeStoreUser, Serializable, XmlO
             case SchemaType.BTC_G_DAY:
             case SchemaType.BTC_G_MONTH:
                 return base.getCalendarValue();
-                case SchemaType.BTC_NOTATION:
+
+            // NB: for string enums we just do java.lang.String
+            // when in the context of unions. It's easier on users.
+            case SchemaType.BTC_NOTATION:
             case SchemaType.BTC_STRING:
             case SchemaType.BTC_ANY_SIMPLE:
-                // return base.getStringValue();
                 return base.getStringValue();
+
             default:
                 assert (false) : "encountered nonprimitive type.";
-                // fallthrough
-
-                // NB: for string enums we just do java.lang.String
-                // when in the context of unions. It's easier on users.
+                return base.getStringValue();
         }
-        return null;
     }
 
     /**


### PR DESCRIPTION
Reordering the switches in `XmlObjectBase.java_value` to put the `default` labels last silently changed what those defaults do when assertions are disabled:

- The outer `default` (unexpected nonprimitive type code) used to fall through to `base.getStringValue()`; after the reorder it fell out of the switch and returned `null`.
- The inner decimal-size `default` (invalid numeric bit count) used to fall through to `base.getBigDecimalValue()`; after the reorder it fell out of the inner switch and dropped into the `BTC_ANY_URI` case, returning the string value instead.

Both paths are unreachable in normal operation (the assertions guard them in dev/test runs), but with `-da` the graceful fallbacks are part of observed behavior. This gives each `default` an explicit `return` matching the pre-reorder fallthrough target, drops the now-unreachable trailing `return null`, and fixes the stray indentation and duplicated comment the reorder left on the string cases.

Compiled and ran `xmlobject.schematypes.detailed.ListAndUnionTests` locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)