### PR TITLE
Contain FileResourceLoader reads to the resource directory

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/schema/FileResourceLoader.java
+++ b/src/main/java/org/apache/xmlbeans/impl/schema/FileResourceLoader.java
@@ -52,12 +52,34 @@ public class FileResourceLoader implements ResourceLoader
             }
             else
             {
-                return Files.newInputStream(new File(_directory, resourceName).toPath());
+                File file = new File(_directory, resourceName);
+                // A resource name is built from an attacker-controllable handle read out of a
+                // compiled .xsb; a handle containing "../" would otherwise let the resolved path
+                // escape the resource directory and read arbitrary .xsb-suffixed files on disk.
+                if (!isContainedIn(file, _directory))
+                {
+                    return null;
+                }
+                return Files.newInputStream(file.toPath());
             }
         }
         catch (IOException e)
         {
             return null;
+        }
+    }
+
+    private static boolean isContainedIn(File file, File directory)
+    {
+        try
+        {
+            String dirPath = directory.getCanonicalPath() + File.separator;
+            String filePath = file.getCanonicalPath();
+            return filePath.startsWith(dirPath);
+        }
+        catch (IOException e)
+        {
+            return false;
         }
     }
 


### PR DESCRIPTION
## Problem

`FileResourceLoader.getResourceAsStream` builds `new File(_directory, resourceName)` and opens it with no containment check:

```java
return Files.newInputStream(new File(_directory, resourceName).toPath());
```

The `resourceName` for a compiled schema component is `getBasePackage() + handle + ".xsb"`, and the `handle` is read verbatim from the `.xsb` index with no validation (`SchemaTypePool.readHandlePool` → `reader.readString()`). A handle such as `../../../../../../etc/passwd` in an **untrusted compiled type system loaded from a directory** (e.g. via `XmlBeans.resourceLoaderForPath(File[])`) therefore resolves outside `_directory` when the component is dereferenced (`SchemaTypeSystemImpl.resolveHandle` → `new XsbReader(...)` → `XsbReader.java:60`). This is an arbitrary read of any `.xsb`-suffixed file on disk, and on Windows a UNC handle triggers SMB egress.

## Fix

Reject any resolved path whose canonical form is not inside the resource directory. Legitimate handles are single filename segments (`NameUtil.upperCamelCase` output, lowercased, with an optional numeric disambiguator), so they always stay inside the directory and are unaffected.

Zip/jar-backed loading already uses `ZipFile.getEntry` — a name lookup that cannot touch the filesystem — so only the directory-backed path needed changing.

## Testing

- `./gradlew compileJava` clean
- `./gradlew test --tests compile.scomp.checkin.CompilationTests` passes (exercises schema compile + load)

🤖 Generated with [Claude Code](https://claude.com/claude-code)