### PR TITLE
Reject remote file: authorities in the schema-download gate

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/schema/StscState.java
+++ b/src/main/java/org/apache/xmlbeans/impl/schema/StscState.java
@@ -438,10 +438,22 @@ public class StscState {
                 int i = s.lastIndexOf('!');
                 return shouldDownloadURI(i > 0 ? s.substring(0, i) : s);
             }
-            return equalsIgnoreCase(uri.getScheme(), "file");
+            return equalsIgnoreCase(uri.getScheme(), "file") && isLocalFileAuthority(uri);
         } catch (Exception e) {
             return false;
         }
+    }
+
+    /**
+     * True if a file: URI has no remote authority. A file: URI with a non-local
+     * host (e.g. a Windows UNC path file://server/share/schema.xsd) would otherwise
+     * be fetched even when network downloads are disabled, letting an untrusted
+     * schema's import/include reach an attacker-controlled host over SMB.
+     */
+    private static boolean isLocalFileAuthority(URI uri) {
+        String authority = uri.getAuthority();
+        return authority == null || authority.isEmpty() ||
+               authority.equalsIgnoreCase("localhost");
     }
 
     /**


### PR DESCRIPTION
## Problem

`StscState.shouldDownloadURI` gates resolution of `<xsd:import>` / `<xsd:include>` / `<xsd:redefine>` `schemaLocation`s. With network downloads disabled (the default), remote `http(s)://` locations are correctly refused — but any `file:` URI was accepted regardless of the gate and **without inspecting the authority**:

```java
return equalsIgnoreCase(uri.getScheme(), "file");   // host never checked
```

An accepted URL reaches `StscImporter.downloadDocument` → `new URL(absoluteURL)` → `loader.parse(url, …)` and is opened. So when an application compiles an **untrusted XSD** with default options, a Windows UNC location like `file://attacker.example.com/share/evil.xsd` in an import passes the gate and triggers an outbound SMB connection to the attacker's host (SSRF with attacker-controlled host **and** protocol, capable of leaking NTLM credentials) — even though the operator has network downloads disabled. A `file:///etc/...` location similarly reaches the local filesystem.

## Fix

Accept a `file:` URI only when it has no remote authority (`null`, empty, or `localhost`). Legitimate local-file includes carry no authority and keep working; a UNC / remote-host `file:` URI is now refused like any other blocked download. The `jar:`/`zip:` recursion just above funnels back through this same check for its embedded URI, so it is covered too.

This does not change the behavior when a caller has opted into downloads (via `setCompileDownloadUrls`, an `EntityResolver`, or `-Dxmlbean.downloadurls=true`), where `_doingDownloads` short-circuits to `true` before this check.

## Testing

- `./gradlew compileJava` clean
- `./gradlew test --tests compile.scomp.checkin.CompilationTests --tests compile.scomp.som.checkin.PartialSOMCheckinTest` passes (exercise schema import/include resolution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)