### PR TITLE
Close the javac pipes and join the drain threads in externalCompile

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/tool/CodeGenUtil.java
+++ b/src/main/java/org/apache/xmlbeans/impl/tool/CodeGenUtil.java
@@ -242,10 +242,23 @@ public class CodeGenUtil {
             StringBuilder errorBuffer = new StringBuilder();
             StringBuilder outputBuffer = new StringBuilder();
 
-            Thread out = copy(proc.getInputStream(), outputBuffer);
-            Thread err = copy(proc.getErrorStream(), errorBuffer);
+            try {
+                // the compiler reads nothing from stdin - leaving the pipe open just
+                // holds a file descriptor until the Process is collected
+                proc.getOutputStream().close();
 
-            proc.waitFor();
+                Thread out = copy(proc.getInputStream(), outputBuffer);
+                Thread err = copy(proc.getErrorStream(), errorBuffer);
+
+                proc.waitFor();
+
+                // the readers can still be draining the pipes after the process exits,
+                // so join before reporting what they collected
+                out.join();
+                err.join();
+            } finally {
+                proc.destroy();
+            }
 
             if (verbose || proc.exitValue() != 0) {
                 if (outputBuffer.length() > 0) {
@@ -347,9 +360,13 @@ public class CodeGenUtil {
      */
     private static Thread copy(InputStream stream, final StringBuilder output) {
         final BufferedReader reader = new BufferedReader(new InputStreamReader(stream, Charset.defaultCharset()));
-        Thread readerThread = new Thread(() ->
-            reader.lines().forEach(s -> output.append(s).append('\n'))
-        );
+        Thread readerThread = new Thread(() -> {
+            try (BufferedReader r = reader) {
+                r.lines().forEach(s -> output.append(s).append('\n'));
+            } catch (IOException e) {
+                // nothing useful to do with a failure to drain the pipe
+            }
+        });
         readerThread.start();
         return readerThread;
     }


### PR DESCRIPTION
`CodeGenUtil.externalCompile` never closed any of the three pipes it opens for the compiler process:

- `proc.getOutputStream()` (stdin, which `javac` never reads) is left open;
- the `BufferedReader`s wrapping stdout and stderr in `copy()` are never closed.

That is three file descriptors per invocation, released only when the `Process` is finally collected.

The drain threads were also never joined. `proc.waitFor()` returns as soon as the process exits, which can be before the reader threads have finished appending, so the compiler diagnostics printed immediately below could be truncated or empty — the `out` and `err` locals were assigned and then never used.

This change closes stdin up front, joins both readers after `waitFor()`, destroys the process in a `finally`, and lets `copy()` close its reader once the pipe is drained.

`compile.scomp.checkin.CompilationTests` (10 tests, all of which shell out to `javac` through this path) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)