### PR TITLE
Close the caller's stream when writeInputStreamToFile can't open the target

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/tool/SchemaResourceManager.java
+++ b/src/main/java/org/apache/xmlbeans/impl/tool/SchemaResourceManager.java
@@ -251,8 +251,13 @@ public class SchemaResourceManager extends BaseSchemaResourceManager
         File parent = targetFile.getParentFile();
         if (!parent.exists())
             parent.mkdirs();
-        OutputStream output = Files.newOutputStream(targetFile.toPath());
-        IOUtil.copyCompletely(input, output);
+        // copyCompletely() closes both streams, but it never runs if the target
+        // cannot be opened - and callers hand us a live download to close
+        try (InputStream in = input;
+             OutputStream output = Files.newOutputStream(targetFile.toPath()))
+        {
+            IOUtil.copyCompletely(in, output);
+        }
     }
 
     /**

--- a/src/test/java/org/apache/xmlbeans/impl/tool/SchemaResourceManagerWriteTest.java
+++ b/src/test/java/org/apache/xmlbeans/impl/tool/SchemaResourceManagerWriteTest.java
@@ -1,0 +1,61 @@
+/*   Licensed to the Apache Software Foundation (ASF) under one or more
+ *   contributor license agreements.  See the NOTICE file distributed with
+ *   this work for additional information regarding copyright ownership.
+ *   The ASF licenses this file to You under the Apache License, Version 2.0
+ *   (the "License"); you may not use this file except in compliance with
+ *   the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.apache.xmlbeans.impl.tool;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SchemaResourceManagerWriteTest {
+
+    private static class TrackingInputStream extends ByteArrayInputStream {
+        private boolean closed;
+
+        TrackingInputStream(byte[] bytes) {
+            super(bytes);
+        }
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+            super.close();
+        }
+    }
+
+    @Test
+    void closesInputWhenTheTargetCannotBeOpened(@TempDir File dir) throws IOException {
+        // a plain file where the target's parent directory should be, so opening
+        // the output fails
+        File blocker = new File(dir, "blocker");
+        assertTrue(blocker.createNewFile());
+
+        SchemaResourceManager manager = new SchemaResourceManager(dir);
+        TrackingInputStream input =
+            new TrackingInputStream("<xsd/>".getBytes(StandardCharsets.UTF_8));
+
+        assertThrows(IOException.class,
+            () -> manager.writeInputStreamToFile(input, "blocker/child.xsd"));
+        assertTrue(input.closed, "the caller's stream should have been closed");
+    }
+}


### PR DESCRIPTION
`SchemaResourceManager.writeInputStreamToFile` leans on `IOUtil.copyCompletely` to close both streams:

```java
OutputStream output = Files.newOutputStream(targetFile.toPath());
IOUtil.copyCompletely(input, output);
```

But `copyCompletely` only runs once the target has been opened. If `Files.newOutputStream` throws — an unwritable directory, a path component that is not a directory, a full disk — the caller's input is never closed.

The callers in `BaseSchemaResourceManager` hand it live downloads: `url.openStream()` (`copyOrIdentifyDuplicateURL`), `conn.getInputStream()` (`redownloadEntry`) and the index document stream (`writeCache`). A write failure there leaks the socket, and `redownloadEntry`/`copyOrIdentifyDuplicateURL` both just `warning(...)` and carry on to the next resource, so this accumulates across a `-refresh` run.

The method now owns the input in a try-with-resources, so it is released either way; the second close on the normal path is a no-op.

Added `SchemaResourceManagerWriteTest`, which puts a plain file where the target's parent directory should be. It fails on trunk and passes with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)