### PR TITLE
Fold _canHavePrefixUri into Xobj._bits to shrink AttrXobj by 8 bytes

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/store/DomImpl.java
+++ b/src/main/java/org/apache/xmlbeans/impl/store/DomImpl.java
@@ -661,7 +661,7 @@ public final class DomImpl {
         c.createElement(l.makeQualifiedQName("", name));
         ElementXobj e = (ElementXobj) c.getDom();
         c.release();
-        e._canHavePrefixUri = false;
+        e.clearBit(Xobj.CAN_HAVE_PREFIX_URI);
         return e;
     }
 
@@ -698,7 +698,7 @@ public final class DomImpl {
         c.createAttr(l.makeQualifiedQName("", name));
         AttrXobj e = (AttrXobj) c.getDom();
         c.release();
-        e._canHavePrefixUri = false;
+        e.clearBit(Xobj.CAN_HAVE_PREFIX_URI);
         return e;
     }
 

--- a/src/main/java/org/apache/xmlbeans/impl/store/NamedNodeXobj.java
+++ b/src/main/java/org/apache/xmlbeans/impl/store/NamedNodeXobj.java
@@ -18,13 +18,12 @@ package org.apache.xmlbeans.impl.store;
 abstract class NamedNodeXobj extends NodeXobj {
     NamedNodeXobj(Locale l, int kind, int domType) {
         super(l, kind, domType);
-        _canHavePrefixUri = true;
+        setBit(CAN_HAVE_PREFIX_URI);
     }
 
     public boolean nodeCanHavePrefixUri() {
-        return _canHavePrefixUri;
+        return bitIsSet(CAN_HAVE_PREFIX_URI);
     }
 
-    boolean _canHavePrefixUri;
 }
 

--- a/src/main/java/org/apache/xmlbeans/impl/store/Xobj.java
+++ b/src/main/java/org/apache/xmlbeans/impl/store/Xobj.java
@@ -567,8 +567,7 @@ abstract class Xobj implements TypeStore {
 
             _name = newName;
             if (this instanceof NamedNodeXobj) {
-                NamedNodeXobj me = (NamedNodeXobj) this;
-                me._canHavePrefixUri = true;
+                setBit(CAN_HAVE_PREFIX_URI);
             }
 
             if (!isProcinst()) {
@@ -1298,6 +1297,9 @@ abstract class Xobj implements TypeStore {
     static final int VACANT = 0x100;
     static final int STABLE_USER = 0x200;
     static final int INHIBIT_DISCONNECT = 0x400;
+    // only NamedNodeXobj reads this one - it lives here so that NamedNodeXobj
+    // needs no field of its own, which would cost 8 bytes per AttrXobj in padding
+    static final int CAN_HAVE_PREFIX_URI = 0x800;
 
     final boolean isVacant() {
         return bitIsSet(VACANT);

--- a/src/test/java/org/apache/xmlbeans/impl/store/NodePrefixUriFlagTest.java
+++ b/src/test/java/org/apache/xmlbeans/impl/store/NodePrefixUriFlagTest.java
@@ -1,0 +1,104 @@
+/*   Licensed to the Apache Software Foundation (ASF) under one or more
+ *   contributor license agreements.  See the NOTICE file distributed with
+ *   this work for additional information regarding copyright ownership.
+ *   The ASF licenses this file to You under the Apache License, Version 2.0
+ *   (the "License"); you may not use this file except in compliance with
+ *   the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.apache.xmlbeans.impl.store;
+
+import org.apache.xmlbeans.XmlCursor;
+import org.apache.xmlbeans.XmlException;
+import org.apache.xmlbeans.XmlObject;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Attr;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import javax.xml.namespace.QName;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * DOM Level 1 factory methods produce nodes with no namespace information, which
+ * the store tracks per node. These pin that behaviour across the three places the
+ * state is written.
+ */
+public class NodePrefixUriFlagTest {
+
+    private static final String URI = "http://example.org/ns";
+
+    private static XmlObject parse() throws XmlException {
+        return XmlObject.Factory.parse("<root/>");
+    }
+
+    private static Document doc() throws XmlException {
+        return (Document) parse().getDomNode();
+    }
+
+    @Test
+    void level1ElementHasNoNamespaceInfo() throws XmlException {
+        Element e = doc().createElement("foo");
+
+        assertNull(e.getLocalName());
+        assertNull(e.getNamespaceURI());
+        assertNull(e.getPrefix());
+    }
+
+    @Test
+    void level2ElementKeepsNamespaceInfo() throws XmlException {
+        Element e = doc().createElementNS(URI, "p:foo");
+
+        assertEquals("foo", e.getLocalName());
+        assertEquals(URI, e.getNamespaceURI());
+        assertEquals("p", e.getPrefix());
+    }
+
+    @Test
+    void level1AttributeHasNoNamespaceInfo() throws XmlException {
+        Attr a = doc().createAttribute("bar");
+
+        assertNull(a.getLocalName());
+        assertNull(a.getNamespaceURI());
+        assertNull(a.getPrefix());
+    }
+
+    @Test
+    void level2AttributeKeepsNamespaceInfo() throws XmlException {
+        Attr a = doc().createAttributeNS(URI, "p:bar");
+
+        assertEquals("bar", a.getLocalName());
+        assertEquals(URI, a.getNamespaceURI());
+        assertEquals("p", a.getPrefix());
+    }
+
+    @Test
+    void renamingALevel1ElementRestoresNamespaceInfo() throws XmlException {
+        XmlObject xo = parse();
+        Document doc = (Document) xo.getDomNode();
+
+        Element child = doc.createElement("child");
+        doc.getDocumentElement().appendChild(child);
+        assertNull(child.getLocalName());
+
+        try (XmlCursor c = xo.newCursor()) {
+            c.toFirstChild(); // root
+            c.toFirstChild(); // child
+            c.setName(new QName(URI, "child", "p"));
+        }
+
+        assertEquals("child", child.getLocalName());
+        assertEquals(URI, child.getNamespaceURI());
+        assertEquals("p", child.getPrefix());
+    }
+}


### PR DESCRIPTION
Refs https://github.com/apache/poi/issues/992, where a 600MB workbook was reported to hold 2.35 million `AttrXobj` (216MB) and 1.17 million `ElementXobj` (108MB).

`NamedNodeXobj` carries one boolean, `_canHavePrefixUri`, recording whether a node came from the DOM Level 1 factory methods (`createElement`/`createAttribute`), which must report `null` for `localName`, `namespaceURI` and `prefix`. `Xobj` already ends exactly on an 8-byte boundary at 88 bytes, so that single byte costs `AttrXobj` a whole slot — 89 bytes of fields padded out to a 96-byte object.

`Xobj._bits` already packs `kind` (`0xF`), `domType` (`0xF0`) and three flags, the highest being `INHIBIT_DISCONNECT = 0x400`. Moving the boolean there as `CAN_HAVE_PREFIX_URI = 0x800` removes the field entirely.

Measured with `Unsafe.objectFieldOffset` on the compiled classes, JDK 17 and JDK 21:

| | trunk | this change |
|---|---|---|
| `Xobj` | 88 | 88 |
| `AttrXobj` | 96 (7 bytes padding) | **88** |
| `ElementXobj` | 96 | 96 |

The saving also holds with `-XX:-UseCompressedOops` (152 → 144). For the reported workload that is roughly 19MB, about 3%.

`ElementXobj` stays at 96 because it adds a 4-byte `_attributes` reference on top of 88; nothing in this change can help there.

### Relation to the patch proposed on the issue

The issue proposes narrowing `_bits` from `int` to `short`, which produces exactly the same layout — I measured both, and combining them gains nothing further. This approach reaches the same result without changing the type, so there is no compound-assignment narrowing or sign-extension behaviour to reason about and no need for the range assertions that patch adds; `_bits` keeps all 32 bits available for future flags. Either is correct; this one is the smaller change to reason about.

### Behaviour

Identical. The bit is set in the `NamedNodeXobj` constructor, cleared at the two DOM Level 1 factory sites, and set again on rename in `Xobj.setName` — the same three writes as before, and `NamedNodeXobj` remains the only reader. No other `Xobj` sets `0x800`.

Added `NodePrefixUriFlagTest`, covering all three write paths. It passes on trunk as well — it is a characterisation test for the invariant this refactor must preserve, not a bug fix.

Full suite: 3182 tests pass (170 skipped), including the W3C DOM conformance suite. `forbiddenApisMain` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)