### PR TITLE
Release the Locale when a SAX load is abandoned

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/store/Locale.java
+++ b/src/main/java/org/apache/xmlbeans/impl/store/Locale.java
@@ -2573,11 +2573,26 @@ public final class Locale
             _context = null;
         }
 
+        /**
+         * Drops a partly built document. The XMLReader holds this handler, and a
+         * caller-supplied one (XmlOptions.setLoadUseXMLReader) outlives the parse, so
+         * an abandoned load must let go of the Locale for the same reason postLoad does.
+         */
+        private void abortLoad() {
+            if (_context != null) {
+                _context.abort();
+            }
+            _locale = null;
+            _context = null;
+        }
+
         public Cur load(Locale l, InputSource is, XmlOptions options)
             throws XmlException, IOException {
             is.setSystemId("file://");
 
             initSaxHandler(l, options);
+
+            boolean loaded = false;
 
             try {
                 _xr.parse(is);
@@ -2587,15 +2602,12 @@ public final class Locale
                 associateSourceName(c, options);
 
                 postLoad(c);
+                loaded = true;
 
                 return c;
             } catch (XmlRuntimeException e) {
-                _context.abort();
-
                 throw new XmlException(e);
             } catch (SAXParseException e) {
-                _context.abort();
-
                 XmlError err =
                     XmlError.forLocation(e.getMessage(),
                         options == null ? null : options.getDocumentSourceName(),
@@ -2603,15 +2615,13 @@ public final class Locale
 
                 throw new XmlException(err.toString(), e, err);
             } catch (SAXException e) {
-                _context.abort();
-
                 XmlError err = XmlError.forMessage(e.getMessage());
 
                 throw new XmlException(err.toString(), e, err);
-            } catch (RuntimeException e) {
-                _context.abort();
-
-                throw e;
+            } finally {
+                if (!loaded) {
+                    abortLoad();
+                }
             }
         }
 

--- a/src/test/java/org/apache/xmlbeans/impl/store/SaxLoaderAbortTest.java
+++ b/src/test/java/org/apache/xmlbeans/impl/store/SaxLoaderAbortTest.java
@@ -1,0 +1,87 @@
+/*   Licensed to the Apache Software Foundation (ASF) under one or more
+ *   contributor license agreements.  See the NOTICE file distributed with
+ *   this work for additional information regarding copyright ownership.
+ *   The ASF licenses this file to You under the Apache License, Version 2.0
+ *   (the "License"); you may not use this file except in compliance with
+ *   the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.apache.xmlbeans.impl.store;
+
+import org.apache.xmlbeans.XmlException;
+import org.apache.xmlbeans.XmlObject;
+import org.apache.xmlbeans.XmlOptions;
+import org.apache.xmlbeans.impl.common.SAXHelper;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.XMLReader;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * A caller-supplied XMLReader outlives the parse and holds the SaxLoader as its
+ * content handler, so anything the loader still points at stays reachable. A load that
+ * completes clears that in postLoad(); one that fails has to do the same.
+ */
+public class SaxLoaderAbortTest {
+
+    private static Object fieldValue(Object target, String name) throws Exception {
+        for (Class<?> c = target.getClass(); c != null; c = c.getSuperclass()) {
+            try {
+                Field f = c.getDeclaredField(name);
+                f.setAccessible(true);
+                return f.get(target);
+            } catch (NoSuchFieldException ignored) {
+                // keep walking up
+            }
+        }
+        throw new NoSuchFieldException(name);
+    }
+
+    private static void assertReaderReleasedItsDocument(String xml, boolean expectFailure)
+        throws Exception {
+        XMLReader xr = SAXHelper.newXMLReader(new XmlOptions());
+        XmlOptions options = new XmlOptions().setLoadUseXMLReader(xr);
+
+        if (expectFailure) {
+            assertThrows(XmlException.class, () -> XmlObject.Factory.parse(xml, options));
+        } else {
+            assertNotNull(XmlObject.Factory.parse(xml, options));
+        }
+
+        ContentHandler handler = xr.getContentHandler();
+        assertNotNull(handler, "the reader should still hold the loader");
+
+        assertNull(fieldValue(handler, "_locale"),
+            "the loader still points at the Locale, keeping the document and its type loader alive");
+        assertNull(fieldValue(handler, "_context"),
+            "the loader still points at the load context");
+    }
+
+    @Test
+    void releasesTheDocumentAfterAFailedParse() throws Exception {
+        assertReaderReleasedItsDocument("<root>", true);
+    }
+
+    @Test
+    void releasesTheDocumentAfterAParseErrorPartWayIn() throws Exception {
+        assertReaderReleasedItsDocument("<root><a/><b></root>", true);
+    }
+
+    @Test
+    void releasesTheDocumentAfterASuccessfulParse() throws Exception {
+        assertReaderReleasedItsDocument("<root><a/></root>", false);
+    }
+}


### PR DESCRIPTION
`SaxLoader.postLoad()` exists to drop the loader's references to the document it just built:

```java
void postLoad(Cur c) {
    // fix garbage collection of Locale -> Xobj -> STL
    _locale = null;
    _context = null;
}
```

It only runs when the parse completes. Every failure path leaves both fields set — the four catch blocks call `_context.abort()` and rethrow without clearing them, and an `IOException` out of `_xr.parse(is)` is not caught at all, so it does not even abort.

That matters because the `XMLReader` holds the `SaxLoader` as its content, DTD, error, lexical and declaration handler. When xmlbeans creates the reader itself the loader becomes garbage anyway, but `XmlOptions.setLoadUseXMLReader(...)` lets a caller supply a reader that outlives the parse — and callers reuse `XmlOptions`. A failed load then pins the partly built document and its `SchemaTypeLoader` on that reader until the next parse, which is exactly the `Locale -> Xobj -> STL` chain the comment above is about.

This aborts and clears from a `finally`, which also covers the previously uncaught `IOException` path. The per-catch `_context.abort()` calls go away, and the `catch (RuntimeException e)` block existed only to abort before rethrowing, so it goes too.

Added `SaxLoaderAbortTest`: it supplies its own `XMLReader`, parses, then reflects on the reader's content handler to check `_locale` and `_context` are cleared. The two failure cases fail on trunk and pass with this change; the success case passes either way and pins the existing `postLoad` behaviour.

Full suite: 3173 tests pass (170 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)