### PR TITLE
Exclude the loopback HTTP server test from the animalsniffer check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -789,3 +789,10 @@ animalsniffer {
     ignore 'javax.xml.namespace.*'
 }
 
+// The Android API signature only makes sense for code we ship. ParseUrlRedirectTest
+// runs a loopback com.sun.net.httpserver server, which is JDK-only and never leaves
+// the test source set.
+animalsnifferTest {
+    exclude '**/ParseUrlRedirectTest*'
+}
+


### PR DESCRIPTION
`ParseUrlRedirectTest`, added in #113, starts a `com.sun.net.httpserver` server on loopback to pin redirect following in `SchemaTypeLoaderBase.parse(URL)`. That package is not part of the Android API signature (`gummy-bears-api-${androidSdkMinimum}`) animalsniffer checks against, so `animalsnifferTest` reports 19 undefined references and `./gradlew check` fails on trunk:

```
> 19 AnimalSniffer violations were found in 1 files.
org.apache.xmlbeans.impl.schema.ParseUrlRedirectTest:38  Undefined reference: com.sun.net.httpserver.HttpServer com.sun.net.httpserver.HttpServer.create(...)
...
```

My fault — I added that test without running `check`. Apologies for the breakage.

The signature describes what the *published artifact* may use. Test code never ships and never runs on Android, so this excludes the one file rather than weakening the signature for `main`:

```groovy
animalsnifferTest {
    exclude '**/ParseUrlRedirectTest*'
}
```

Excluding the whole test source set would also work — the `animalsniffer` block already carries a commented-out `sourceSets = [sourceSets.main]` for exactly that — but this keeps the rest of the tests covered. Happy to switch to the broader form if you'd prefer it.

`./gradlew animalsnifferTest animalsnifferMain` passes; the task still runs, with only that file filtered out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)